### PR TITLE
strip trailing slash and remove now unneeded "Note:"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ To include the components in an HTML template:
 - Add the stylesheets for Fonts and Vocabulary
 - Add the build version of the components via a script tag (the output of `npm run build:unpkg`)
 - Import each component, passing it's respective attribute as such and mount it on a corresponding `div` element.
-  - CC Global Header has two required attributes, `base-url` and `donation-url` , which are the URLs used for the API call and the Donation button respectively. For a development environment, the `base-url` could be `http://127.0.0.1:8000`. Note: the `base-url` value should not have a trailing slash.
+  - CC Global Header has two required attributes, `base-url` and `donation-url` , which are the URLs used for the API call and the Donation button respectively. For a development environment, the `base-url` could be `http://127.0.0.1:8000`.
     - `<cc-global-header base-url="http://127.0.0.1:8000" donation-url="http:/example.com" />`
   - CC Global Footer and CC Explore have just one required attribute each, a `donation-url` attribute which is the URL used for the Donation buttons.
     - `<cc-global-footer donation-url="http://example.com" />`

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ CC Global Footer requires a `donation-url` attribute which is the URL used for t
 
 ### CC Global Header
 
-The CC Global Header has two required attributes, `base-url` and `donation-url` , which are the URLs used for the API call and the Donation button respectively. For a development environment, the `base-url` could be `http://127.0.0.1:8000`. Note: the `base-url` value should not have a trailing slash.
+The CC Global Header has two required attributes, `base-url` and `donation-url` , which are the URLs used for the API call and the Donation button respectively. For a development environment, the `base-url` could be `http://127.0.0.1:8000`.
 
 ```html
 <cc-global-header

--- a/src/components/cc-global-header.vue
+++ b/src/components/cc-global-header.vue
@@ -96,7 +96,7 @@ export default defineComponent({
   name: "cc-golbal-header",
   beforeCreate() {
     var requestPath = "/wp-json/ccnavigation-header/menu";
-    var requestUrl = this.baseUrl + requestPath;
+    var requestUrl = this.baseUrl.replace(/\/$/, '') + requestPath;
     axios
       .get(requestUrl)
       .then((response) => (this.menus = response.data));


### PR DESCRIPTION
## Fixes
Fixes #13 
- #13 

## Description
strip trailing slash and remove now unneeded "Note:"

## Caveat
I'm not vary familiar with JavaScript nor Vue. I don't know if the following is a better solution:
```diff
--- src/components/cc-global-header.vue
+++ src/components/cc-global-header.vue
@@ -94,9 +94,9 @@ if (process.env.NODE_ENV === "development") {
 }
 export default defineComponent({
   name: "cc-golbal-header",
-  beforeCreate() {
+  created() {
     var requestPath = "/wp-json/ccnavigation-header/menu";
-    var requestUrl = this.baseUrl.replace(/\/$/, '') + requestPath;
+    var requestUrl = this.apiUrl + requestPath;
     axios
       .get(requestUrl)
       .then((response) => (this.menus = response.data));
@@ -119,6 +119,11 @@ export default defineComponent({
       required: true,
     },
   },
+  computed: {
+    apiUrl: function () {
+        return this.baseUrl.replace(/\/$/, '');
+    }
+  },
   data() {
     return {
       isBurgerMenuActive: false,
```



## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
      visible errors.

[best_practices]: https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
