### PR TITLE
Add loading text when API request is sent

### DIFF
--- a/src/components/cc-global-header.vue
+++ b/src/components/cc-global-header.vue
@@ -35,7 +35,7 @@
       >
         <div class="navbar-end">
           <p v-if="menuLoading" class="navbar-item navbar-link is-arrowless">
-            Loading menu..
+            Loading menu.
           </p>
           <p
             v-else

--- a/src/components/cc-global-header.vue
+++ b/src/components/cc-global-header.vue
@@ -41,7 +41,7 @@
             We are having trouble loading the menu
             <br />
             Error Message: {{ errorMessage }}.
-          ></p>
+          </p>
           <div class="" v-for="menu in menus" :key="menu.ID">
             <a
               v-if="!menu.child_items"

--- a/src/components/cc-global-header.vue
+++ b/src/components/cc-global-header.vue
@@ -137,7 +137,7 @@ export default defineComponent({
         })
         .catch((error) => {
           vm.menuLoading = false;
-          vm.errorMessage = `We are having trouble loading the menu <br /> Error Message: ${error.message}.`;
+          vm.errorMessage = error.message;
         });
     }
   },

--- a/src/components/cc-global-header.vue
+++ b/src/components/cc-global-header.vue
@@ -34,11 +34,14 @@
         :class="{ ['navbar-menu']: true, ['is-active']: isBurgerMenuActive }"
       >
         <div class="navbar-end">
-          <p v-if="errorMessage" class="navbar-item navbar-link is-arrowless">
-            We are having trouble loading the menu
-            <br />
-            Error Message: {{ errorMessage }}.
+          <p v-if="menuLoading" class="navbar-item navbar-link is-arrowless">
+            Loading menu..
           </p>
+          <p
+            v-else
+            v-html="errorMessage"
+            class="navbar-item navbar-link is-arrowless"
+          ></p>
           <div class="" v-for="menu in menus" :key="menu.ID">
             <a
               v-if="!menu.child_items"
@@ -124,11 +127,17 @@ export default defineComponent({
         { ID: 4, url: "#", title: "Menu 4" },
       ];
     } else {
+      vm.menuLoading = true;
       axios
         .get(requestUrl)
-        .then((response) => (vm.menus = response.data))
+        .then((response) => {
+          vm.menuLoading = false;
+          vm.errorMessage = null;
+          vm.menus = response.data;
+        })
         .catch((error) => {
-          vm.errorMessage = error.message;
+          vm.menuLoading = false;
+          vm.errorMessage = `We are having trouble loading the menu <br /> Error Message: ${error.message}.`;
         });
     }
   },
@@ -158,6 +167,7 @@ export default defineComponent({
       isBurgerMenuActive: false,
       menus: {},
       errorMessage: "",
+      menuLoading: false,
     };
   },
   methods: {

--- a/src/components/cc-global-header.vue
+++ b/src/components/cc-global-header.vue
@@ -37,10 +37,10 @@
           <p v-if="menuLoading" class="navbar-item navbar-link is-arrowless">
             Loading menu.
           </p>
-          <p
-            v-else
-            v-html="errorMessage"
-            class="navbar-item navbar-link is-arrowless"
+          <p v-if="errorMessage" class="navbar-item navbar-link is-arrowless">
+            We are having trouble loading the menu
+            <br />
+            Error Message: {{ errorMessage }}.
           ></p>
           <div class="" v-for="menu in menus" :key="menu.ID">
             <a


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->

Closes #25  by @brylie 

## Description

This PR introduces a new boolean variable `menuLoading` which is used to display a `Loading menu` message when the API request is sent. If the API request is successful, the Menu items are displayed, else the error is displayed to the user.

## Screenshots
### When the API request is sent and there is an error causing a failure. 
![chrome-capture load failed](https://user-images.githubusercontent.com/40151808/146385886-917f5c82-26f1-420e-bbdd-d394d7e6d7f9.gif)


### When the API request is sent successfully.
![chrome-capture loading pass](https://user-images.githubusercontent.com/40151808/146386104-4deda283-1959-4ed5-a802-a2dc1823a48f.gif)


**Note** The retries feature has not been added here since it will be handled in a separate issue:
- [x] https://github.com/creativecommons/cc-global-components/issues/26


## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
      visible errors.

[best_practices]: https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
