### PR TITLE
Remove double Nav menu 

### DIFF
--- a/src/components/cc-global-header.vue
+++ b/src/components/cc-global-header.vue
@@ -13,7 +13,13 @@
             <img :src="logoUrl" alt="Logo" />
           </div>
         </a>
-        <a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false" @click="toggleBurgerActive()">
+        <a
+          role="button"
+          class="navbar-burger"
+          aria-label="menu"
+          aria-expanded="false"
+          @click="toggleBurgerActive()"
+        >
           <span aria-hidden="true"></span>
           <span aria-hidden="true"></span>
           <span aria-hidden="true"></span>
@@ -217,22 +223,25 @@ export default defineComponent({
 </script>
 <style scoped>
 a.donate {
-    font-family: "Source Sans Pro",sans-serif;
-    text-transform: none;
-    color: #d14500;
-    background-color: #feede9;
-    border-color: #feede9;
-    line-height: 19px;
-    font-size: 0.75rem;
-    padding: calc(0.25rem - 0.7px) 0.5rem calc(0.25rem - 0.7px) 0.25rem;
-    height: unset;
-    margin-right: 8em;
+  font-family: "Source Sans Pro", sans-serif;
+  text-transform: none;
+  color: #d14500;
+  background-color: #feede9;
+  border-color: #feede9;
+  line-height: 19px;
+  font-size: 0.75rem;
+  padding: calc(0.25rem - 0.7px) 0.5rem calc(0.25rem - 0.7px) 0.25rem;
+  height: unset;
+  margin-right: 8em;
 }
 
-i.icon, .button.icon {
+i.icon,
+.button.icon {
   height: unset;
 }
-.navbar-link, .navbar-item, .navbar-burger {
+.navbar-link,
+.navbar-item,
+.navbar-burger {
   color: #767676;
   cursor: pointer;
   background: transparent;
@@ -245,7 +254,7 @@ i.icon, .button.icon {
 }
 
 .button .icon:first-child:last-child {
-    margin-right: 1px; 
+  margin-right: 1px;
 }
 
 svg {

--- a/src/components/cc-global-header.vue
+++ b/src/components/cc-global-header.vue
@@ -1,17 +1,11 @@
 <template>
   <header class="vocab header">
-    <nav class="navbar is-default">
-      <div class="navbar-brand"></div>
-      <div class="navbar-menu">
-        <div class="navbar-start">
-          <!-- Donate button -->
-          <a class="button donate" :href="donationUrl" target="_blank">
-            <i class="icon heart"></i>
-            Donate
-          </a>
-        </div>
-      </div>
-    </nav>
+    <div class="is-flex is-justify-content-flex-end">
+      <a class="button donate" :href="donationUrl" target="_blank">
+        <i class="icon heart"></i>
+        Donate
+      </a>
+    </div>
     <nav class="navbar" :aria-label="ariaPrimaryLabel">
       <div class="navbar-brand column is-one-fifth">
         <a class="main-logo" href="/" target="_blank">
@@ -222,6 +216,22 @@ export default defineComponent({
 });
 </script>
 <style scoped>
+a.donate {
+    font-family: "Source Sans Pro",sans-serif;
+    text-transform: none;
+    color: #d14500;
+    background-color: #feede9;
+    border-color: #feede9;
+    line-height: 19px;
+    font-size: 0.75rem;
+    padding: calc(0.25rem - 0.7px) 0.5rem calc(0.25rem - 0.7px) 0.25rem;
+    height: unset;
+    margin-right: 8em;
+}
+
+i.icon, .button.icon {
+  height: unset;
+}
 .navbar-link, .navbar-item, .navbar-burger {
   color: #767676;
   cursor: pointer;
@@ -233,6 +243,11 @@ export default defineComponent({
   text-transform: uppercase;
   line-height: 1.5;
 }
+
+.button .icon:first-child:last-child {
+    margin-right: 1px; 
+}
+
 svg {
   height: 73px;
 }


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->

Fixes https://github.com/creativecommons/project_creativecommons.org/issues/246 by @brylie 

## Description
The issue was caused by how the `donate` button was being rendered. This was previously rendered using the same markup as nav menus. This PR changes that to use a simple flex-box container. 

## Screenshots
![image](https://user-images.githubusercontent.com/40151808/156725177-627c3fb4-fa23-4538-98a6-e04156ca34fb.png)

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
      visible errors.

[best_practices]: https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
